### PR TITLE
Include generated critical css in assets list in webpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - stable
   - "6"
+  - "4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "critical-webpack-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Webpack wrapper for critical css extraction",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const CriticalWebpackPlugin = require('../index.js');
 const expect = require('expect.js');
 const webpackMock = require('webpack-mock');
@@ -35,20 +37,14 @@ describe('CriticalWebpackPlugin plugin', () => {
     expect(critical.verbose).to.equal(false);
   });
 
-  it('should extract critical css', () => {
-    expect(critical.execute()).to.equal(true);
-  });
-
-  it('should apply compiler (webpack-mock)', () => {
+  it('can be called in webpack (use of webpack-mock)', () => {
     critical.apply(webpackMock);
   });
 
-  it('should fetch content if the source is a remote URL', () => {
+  it('can fetch content if the source is a remote URL', () => {
     delete critical.criticalOptions.base;
-
     critical.criticalOptions.src = 'http://iscor.me';
-    critical.criticalOptions.destFolder = 'tmp';
 
-    critical.execute();
+    critical.apply(webpackMock);
   });
 });


### PR DESCRIPTION
# Pull request

## Proposal

### What kind of change does this PR introduce?

This plugin is now suitable with wepback flow ! 🎉 😄 
Files are generated at emit step in webpack build and can be modified or used by other plugins.

### Did you add tests for your changes?

Yes. I also add `node v4.x` compatibility ❤️ 

### Summary

Generated css is not included in the assets list and cannot be modified by other plugins.

### Other information

Issue: #14

### GIF

![Perfect](http://i.giphy.com/dkv1NNlVYCf6w.gif)
